### PR TITLE
Remove MODULE_SUPPORTED_DEVICE

### DIFF
--- a/dkms/joydev_dance-1.0/joydev_dance/joydev_dance.c
+++ b/dkms/joydev_dance-1.0/joydev_dance/joydev_dance.c
@@ -26,7 +26,6 @@
 
 MODULE_AUTHOR("Vojtech Pavlik <vojtech@ucw.cz>, Adiel Mittmann <adiel@mittmann.net.br>");
 MODULE_DESCRIPTION("Joystick device interfaces (patched with axis fix for dance pad)");
-MODULE_SUPPORTED_DEVICE("input/js");
 MODULE_LICENSE("GPL");
 
 #define JOYDEV_MINOR_BASE	0


### PR DESCRIPTION
As per https://lkml.org/lkml/2021/3/17/518 MODULE_SUPPORTED_DEVICE was
never implemented and has been recently removed from kernel causing
compilation errors. This fixes #8.